### PR TITLE
Update from SDK 2.0.0RC3 to 2.0.0RC5

### DIFF
--- a/azure_rm_common.py
+++ b/azure_rm_common.py
@@ -79,14 +79,10 @@ try:
     from azure.mgmt.network.models import PublicIPAddress, NetworkSecurityGroup, SecurityRule, NetworkInterface, \
         NetworkInterfaceIPConfiguration, Subnet
     from azure.common.credentials import ServicePrincipalCredentials, UserPassCredentials
-    from azure.mgmt.network.network_management_client import NetworkManagementClient,\
-                                                             NetworkManagementClientConfiguration
-    from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient,\
-                                                                         ResourceManagementClientConfiguration
-    from azure.mgmt.storage.storage_management_client import StorageManagementClient,\
-                                                             StorageManagementClientConfiguration
-    from azure.mgmt.compute.compute_management_client import ComputeManagementClient,\
-                                                             ComputeManagementClientConfiguration
+    from azure.mgmt.network.network_management_client import NetworkManagementClient
+    from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient
+    from azure.mgmt.storage.storage_management_client import StorageManagementClient
+    from azure.mgmt.compute.compute_management_client import ComputeManagementClient
     from azure.storage.cloudstorageaccount import CloudStorageAccount
 except ImportError, exc:
     HAS_AZURE_EXC = exc
@@ -596,9 +592,8 @@ class AzureRMModuleBase(object):
     def storage_client(self):
         self.log('Getting storage client...')
         if not self._storage_client:
-            config = StorageManagementClientConfiguration(self.azure_credentials, self.subscription_id)
-            config.add_user_agent(ANSIBLE_USER_AGENT)
-            self._storage_client = StorageManagementClient(config)
+            self._storage_client = StorageManagementClient(self.azure_credentials, self.subscription_id)
+            self._storage_client.config.add_user_agent(ANSIBLE_USER_AGENT)
             self._register('Microsoft.Storage')
         return self._storage_client
 
@@ -606,9 +601,8 @@ class AzureRMModuleBase(object):
     def network_client(self):
         self.log('Getting network client')
         if not self._network_client:
-            config = NetworkManagementClientConfiguration(self.azure_credentials, self.subscription_id)
-            config.add_user_agent(ANSIBLE_USER_AGENT)
-            self._network_client = NetworkManagementClient(config)
+            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id)
+            self._network_client.config.add_user_agent(ANSIBLE_USER_AGENT)
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -616,17 +610,15 @@ class AzureRMModuleBase(object):
     def rm_client(self):
         self.log('Getting resource manager client')
         if not self._resource_client:
-            config = ResourceManagementClientConfiguration(self.azure_credentials, self.subscription_id)
-            config.add_user_agent(ANSIBLE_USER_AGENT)
-            self._resource_client = ResourceManagementClient(config)
+            self._resource_client = ResourceManagementClient(self.azure_credentials, self.subscription_id)
+            self._resource_client.config.add_user_agent(ANSIBLE_USER_AGENT)
         return self._resource_client
 
     @property
     def compute_client(self):
         self.log('Getting compute client')
         if not self._compute_client:
-            config = ComputeManagementClientConfiguration(self.azure_credentials, self.subscription_id)
-            config.add_user_agent(ANSIBLE_USER_AGENT)
-            self._compute_client = ComputeManagementClient(config)
+            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id)
+            self._compute_client.config.add_user_agent(ANSIBLE_USER_AGENT)
             self._register('Microsoft.Compute')
         return self._compute_client

--- a/azure_rm_common.py
+++ b/azure_rm_common.py
@@ -454,13 +454,11 @@ class AzureRMModuleBase(object):
                     azure_object.name, azure_object.provisioning_state, AZURE_SUCCESS_STATE))
 
     def get_blob_client(self, resource_group_name, storage_account_name):
-        keys = dict()
         try:
             # Get keys from the storage account
             self.log('Getting keys')
             account_keys = self.storage_client.storage_accounts.list_keys(resource_group_name, storage_account_name)
-            keys['key1'] = account_keys.key1
-            keys['key2'] = account_keys.key2
+            keys = {v.key_name: v.value for v in account_keys.keys}
         except Exception, exc:
             self.fail("Error getting keys for account {0} - {1}".format(storage_account_name, str(exc)))
 

--- a/azure_rm_deployment.py
+++ b/azure_rm_deployment.py
@@ -373,8 +373,8 @@ try:
                                                       Deployment,
                                                       ResourceGroup,
                                                       Dependency)
-    from azure.mgmt.resource.resources import ResourceManagementClient, ResourceManagementClientConfiguration
-    from azure.mgmt.network import NetworkManagementClient, NetworkManagementClientConfiguration
+    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.network import NetworkManagementClient
 
 except ImportError:
     # This is handled in azure_rm_common

--- a/inventory/azure_rm.py
+++ b/inventory/azure_rm.py
@@ -195,12 +195,9 @@ try:
     from azure.mgmt.compute import __version__ as azure_compute_version
     from azure.common import AzureMissingResourceHttpError, AzureHttpError
     from azure.common.credentials import ServicePrincipalCredentials, UserPassCredentials
-    from azure.mgmt.network.network_management_client import NetworkManagementClient,\
-                                                             NetworkManagementClientConfiguration
-    from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient,\
-                                                                         ResourceManagementClientConfiguration
-    from azure.mgmt.compute.compute_management_client import ComputeManagementClient,\
-                                                             ComputeManagementClientConfiguration
+    from azure.mgmt.network.network_management_client import NetworkManagementClient
+    from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient
+    from azure.mgmt.compute.compute_management_client import ComputeManagementClient
 except ImportError as exc:
     HAS_AZURE_EXC = exc
     HAS_AZURE = False
@@ -363,7 +360,7 @@ class AzureRM(object):
         self.log('Getting network client')
         if not self._network_client:
             self._network_client = NetworkManagementClient(
-                NetworkManagementClientConfiguration(self.azure_credentials, self.subscription_id))
+                self.azure_credentials, self.subscription_id)
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -372,7 +369,7 @@ class AzureRM(object):
         self.log('Getting resource manager client')
         if not self._resource_client:
             self._resource_client = ResourceManagementClient(
-                ResourceManagementClientConfiguration(self.azure_credentials, self.subscription_id))
+                self.azure_credentials, self.subscription_id)
         return self._resource_client
 
     @property
@@ -380,7 +377,7 @@ class AzureRM(object):
         self.log('Getting compute client')
         if not self._compute_client:
             self._compute_client = ComputeManagementClient(
-                ComputeManagementClientConfiguration(self.azure_credentials, self.subscription_id))
+                self.azure_credentials, self.subscription_id)
             self._register('Microsoft.Compute')
         return self._compute_client
 


### PR DESCRIPTION
Hi,

I'm the owner of the Azure SDK for Python at Microsoft. We just released the new 2.0.0RC4 with a little breaking change on the client creation (The XXXConfiguration classes no longer exist). You can find the release note with this change here:
https://github.com/Azure/azure-sdk-for-python/releases/tag/v2.0.0rc4

This is the code which needs to be modified to update from 2.0.0RC3 to 2.0.0RC4.

I will update module-extra as well asap.

Tell me if you need something else or if I can help.

Thank you!
